### PR TITLE
Apply configured blacklists to usernames (fix for #7) + remove template name in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'GradlePluginTemplate'
+rootProject.name = 'ChatGuard'
 

--- a/src/main/java/io/github/aleksandarharalanov/chatguard/ChatGuard.java
+++ b/src/main/java/io/github/aleksandarharalanov/chatguard/ChatGuard.java
@@ -42,6 +42,7 @@ public class ChatGuard extends JavaPlugin {
         pM.registerEvent(Type.PLAYER_COMMAND_PREPROCESS, pCPL, Priority.Lowest, this);
         pM.registerEvent(Type.PLAYER_CHAT, pCL, Priority.Lowest, this);
         pM.registerEvent(Type.PLAYER_JOIN, pJL, Priority.Normal, this);
+        pM.registerEvent(Type.PLAYER_PRELOGIN, pJL, Priority.Lowest, this);
 
         final ChatGuardCommand command = new ChatGuardCommand(this);
         getCommand("chatguard").setExecutor(command);

--- a/src/main/java/io/github/aleksandarharalanov/chatguard/handler/FilterHandler.java
+++ b/src/main/java/io/github/aleksandarharalanov/chatguard/handler/FilterHandler.java
@@ -34,6 +34,13 @@ public class FilterHandler {
         return false;
     }
 
+    public static boolean shouldBlockName(String playerName) {
+        String sanitizedMessage = playerName.toLowerCase();
+        Set<String> whitelistTerms = new HashSet<>(getConfig().getStringList("filter.rules.terms.whitelist", new ArrayList<>()));
+        for (String term : whitelistTerms) sanitizedMessage = sanitizedMessage.replaceAll(term, "");
+        return containsBlacklistedTerms(sanitizedMessage) || matchesRegExPatterns(sanitizedMessage);
+    }
+
     private static boolean containsBlacklistedTerms(String message) {
         Set<String> blacklistTerms = new HashSet<>(getConfig().getStringList("filter.rules.terms.blacklist", new ArrayList<>()));
         String[] messageTerms = message.split("\\s+");

--- a/src/main/java/io/github/aleksandarharalanov/chatguard/listener/player/PlayerJoinListener.java
+++ b/src/main/java/io/github/aleksandarharalanov/chatguard/listener/player/PlayerJoinListener.java
@@ -1,9 +1,12 @@
 package io.github.aleksandarharalanov.chatguard.listener.player;
 
+import org.bukkit.ChatColor;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
+import org.bukkit.event.player.PlayerPreLoginEvent;
 
 import static io.github.aleksandarharalanov.chatguard.ChatGuard.getStrikes;
+import static io.github.aleksandarharalanov.chatguard.handler.FilterHandler.shouldBlockName;
 
 public class PlayerJoinListener extends PlayerListener {
 
@@ -13,6 +16,19 @@ public class PlayerJoinListener extends PlayerListener {
         if (getStrikes().getInt(playerName, -1) == -1) {
             getStrikes().setProperty(playerName, 0);
             getStrikes().saveConfig();
+        }
+
+        // this may be slightly redundant, but i will add it here just in case the pre-login event somehow fails
+        if (shouldBlockName(playerName)) {
+            event.getPlayer().kickPlayer(ChatColor.RED + "Username contains blacklisted terms.");
+        }
+    }
+
+    @Override
+    public void onPlayerPreLogin(PlayerPreLoginEvent event) {
+        String playerName = event.getName();
+        if (shouldBlockName(playerName)) {
+            event.disallow(PlayerPreLoginEvent.Result.KICK_BANNED, ChatColor.RED + "Username contains blacklisted terms.");
         }
     }
 }


### PR DESCRIPTION
This will fix players being able to use blacklisted keywords in their usernames. Fixes issue https://github.com/AleksandarHaralanov/ChatGuard/issues/7.